### PR TITLE
lots of modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.out
 iterate_shell
 *.a
+.DS_Store

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,8 +1,10 @@
 #include "../shell.h"
 
-int main(int argc, char **argv) {
+int main() {
+  
+  char c = '\0';
 
-  while (true) {
+  while (c != EOF) {
     get_comand();
   }
   return 0;

--- a/shell.cpp
+++ b/shell.cpp
@@ -38,79 +38,74 @@ struct Path {
   }
 };
 
-vector<string> parsing (string input_line){
-  for (size_t i = 0; i < input_line.size(); i++) {
-    if(input_line.at(i) == '|'){
-      add_spaces(input_line, i, i + 2);
+void parse(char *line, char *argv[]) {
+
+  while(*line != '\0') {
+    while(*line == ' ' 
+      || *line == '\n' 
+      || *line == '\t') {
+      *line++ = '\0';
     }
-    if(input_line.at(i) == '<'
-    && input_line.at(i + 1) != '<'){
-      add_spaces(input_line, i, i + 2);
-    }
-    if(input_line.at(i) == '>'
-    && input_line.at(i + 1) != '>'){
-      add_spaces(input_line, i, i + 2);
-    }
-    if(input_line.at(i) == '>'
-    && input_line.at(i + 1) == '>'){
-      add_spaces(input_line, i, i + 3);
-    }
-    if(input_line.at(i) == '<'
-    && input_line.at(i + 1) == '<'){
-      add_spaces(input_line, i, i + 3);
+    *argv++ = line; //saves the position
+    //traverse to the end of the command
+    while (*line != '\0' 
+      && *line != ' ' 
+      && *line != '\t' 
+      && *line != '\n') {
+    	if(special_char(line)) { //detect chars and print
+    		cout << "special_char is: " << give_me_color(2) << *line << give_me_color(0) << endl;
+    	}
+      line++;
     }
   }
-  stringstream ss (input_line) ;
-  vector<string> return_value ;
-  for (string word; ss>>word;) {
-    return_value.push_back(word);
-  }
-  for (size_t i = 0; i < return_value.size(); i++) {
-    cout << give_me_color(1) << return_value[i] << give_me_color(0) << endl;
-  }
-  return return_value;
+  argv[sizeof(line)+1] = NULL; //end of arguments sentinel is NULL
 }
 
-void add_spaces(string input_line, size_t& pos1, size_t pos2) {
-    input_line.insert(pos1, " ");
-    input_line.insert(pos2, " ");
-    pos1 = pos2 - pos1 - 1;
+int special_char(char *sp_char) {
+	if (*sp_char == '|' 
+		|| *sp_char == '<' 
+		|| *sp_char == '>') {
+		return 1;
+	}
+return 0;
 }
 
-void fork_exec(vector<string> vector_arg){
-    //execvp accepts only an array of string pointers
-    const char *program =(vector_arg[0]).c_str();
-    const char **arg = new const char* [vector_arg.size()+2];  //extra space for program name and sentinel
-    arg [0] = program;
-    for (size_t i = 0;  i < vector_arg.size()+1;  ++i)
-            arg [i+1] = (vector_arg[i]).c_str();
+void fork_exec(char *argv[]) {
 
-    arg [vector_arg.size()+1] = NULL;  // end of arguments sentinel is NULL
+  //execvp implementation yet
+  int status;
 
-    int pid =fork();
-    if(pid == -1){
-        cout << "OH NO :( I am sick, can't do that";
-    }
-    else if(pid == 0){
-        //child
-        //exec is execute, 'p': give the name of the program and the operating system will look for the program in the path
-        execvp(program, (char **)arg );
-    }
-    else{
-        //parent
-          waitpid(pid, NULL, 0);
-    }
+  if(strcmp(argv[0], "exit") == 0) {
+    exit(0);
+  }
+
+  pid_t pid = fork(); //pid_t is better to avoid int size regardless of int size in different systems
+  if(pid == -1){
+    cout << "OH NO :( I am sick, can't do that";
+  }
+  else if(pid == 0) {
+    //child
+    //exec is execute, 'p': give the name of the program and the operating system will look for the program in the path
+    execvp(*argv, argv);
+  }
+  else {
+    //parent
+    waitpid(pid, &status, 0);
+  }
 }
 
 void get_comand(void) {
 
   string input_line;
-  vector<string> parsed_commands;
-  cout << "[oh my gosh shell] $ ";
-  getline (cin, input_line) ;
-  parsed_commands = parsing(input_line);
+  char line[1024];
+  char *argv[1024];
 
-  fork_exec(parsed_commands);
+  cout << "[oh my gosh shell] $ ";
+  getline(cin, input_line);
+  strcpy(line, input_line.c_str()); //string to char array converter
+  cout << give_me_color(1) << line << give_me_color(0) << endl;
+  parse(line, argv);
+  fork_exec(argv);
 }
 
 string give_me_color(int color_index) {

--- a/shell.h
+++ b/shell.h
@@ -1,14 +1,17 @@
 #pragma once
 #include <iostream>
 #include <unistd.h>
+#include <cstring>
 #include <string>
 #include <vector>
 #include <sstream>
+#include <cstdio>
 #include <sys/types.h>
 #include <sys/wait.h>
 
 void get_comand(void);
-std::vector <std::string> parasing (std::string inputLine);
-void add_spaces(std::string input_line, size_t& pos1, size_t pos2);
+void parse(char *line, char *argv[]);
+void fork_exec(char *argv[]);
+int special_char(char *special_char); //return type should be changed
 struct Path;
 std::string give_me_color(int);


### PR DESCRIPTION
change parsing from vector to char (see **footnote**)
separate parsing from execute
implement required functions
remove add spaces and old special char detection.

**footnote:** `execve` requires char type in order to execute the program,
so it seems more logical to parse it as char and
save it in vector later for further needs. (_e.g. history of commands_)